### PR TITLE
Fix workflow dispatch input items order

### DIFF
--- a/templates/repo/actions/list.tmpl
+++ b/templates/repo/actions/list.tmpl
@@ -77,7 +77,7 @@
 					{{end}}
 				</div>
 
-				{{if .WorkflowDispatchConfig}}
+				{{if .WorkflowDispatchInputs}}
 					{{template "repo/actions/workflow_dispatch" .}}
 				{{end}}
 

--- a/templates/repo/actions/workflow_dispatch.tmpl
+++ b/templates/repo/actions/workflow_dispatch.tmpl
@@ -39,30 +39,32 @@
 			</div>
 
 			<div class="divider"></div>
-			{{range $key, $item := .WorkflowDispatchConfig.Inputs}}
-			<div class="ui field {{if .Required}}required{{end}}">
-				{{if eq .Type "choice"}}
+			{{range $idx, $val := .WorkflowDispatchInputs}}
+			{{ $key := $val.Key }}
+			{{ $item := $val.Value }}
+			<div class="ui field {{if $item.Required}}required{{end}}">
+				{{if eq $item.Type "choice"}}
 					<label>{{$key}} :</label>
 					<select class="ui fluid dropdown" name="{{$key}}">
-						{{range .Options}}
+						{{range $item.Options}}
 						<option value="{{.}}" {{if eq $item.Default .}}selected{{end}} >{{.}}</option>
 						{{end}}
 					</select>
-					<span class="help">{{.Description}}</span>
-				{{else if eq .Type "boolean"}}
+					<span class="help">{{$item.Description}}</span>
+				{{else if eq $item.Type "boolean"}}
 					<div class="ui inline toggle checkbox">
 						<label>{{$key}}</label>
-						<input type="checkbox" name="{{$key}}" {{if eq .Default "true"}}checked{{end}}>
-						<span class="help">{{.Description}}</span>
+						<input type="checkbox" name="{{$key}}" {{if eq $item.Default "true"}}checked{{end}}>
+						<span class="help">{{$item.Description}}</span>
 					</div>
-				{{else if eq .Type "number"}}
+				{{else if eq $item.Type "number"}}
 					<label>{{$key}} :</label>
-					<input name="{{$key}}" value="{{.Default}}" {{if .Required}}required{{end}}>
-					<span class="help">{{.Description}}</span>
+					<input name="{{$key}}" value="{{$item.Default}}" {{if $item.Required}}required{{end}}>
+					<span class="help">{{$item.Description}}</span>
 				{{else}}
 					<label>{{$key}} :</label>
-					<input name="{{$key}}" value="{{.Default}}" {{if .Required}}required{{end}}>
-					<span class="help">{{.Description}}</span>
+					<input name="{{$key}}" value="{{$item.Default}}" {{if $item.Required}}required{{end}}>
+					<span class="help">{{$item.Description}}</span>
 				{{end}}
 			</div>
 			{{end}}

--- a/templates/repo/actions/workflow_dispatch.tmpl
+++ b/templates/repo/actions/workflow_dispatch.tmpl
@@ -44,27 +44,23 @@
 			{{ $item := $val.Value }}
 			<div class="ui field {{if $item.Required}}required{{end}}">
 				{{if eq $item.Type "choice"}}
-					<label>{{$key}} :</label>
+					<label title="Input: {{$key}}">{{$item.Description}} :</label>
 					<select class="ui fluid dropdown" name="{{$key}}">
 						{{range $item.Options}}
 						<option value="{{.}}" {{if eq $item.Default .}}selected{{end}} >{{.}}</option>
 						{{end}}
 					</select>
-					<span class="help">{{$item.Description}}</span>
 				{{else if eq $item.Type "boolean"}}
 					<div class="ui inline toggle checkbox">
-						<label>{{$key}}</label>
+						<label title="Input: {{$key}}">{{$item.Description}}</label>
 						<input type="checkbox" name="{{$key}}" {{if eq $item.Default "true"}}checked{{end}}>
-						<span class="help">{{$item.Description}}</span>
 					</div>
 				{{else if eq $item.Type "number"}}
-					<label>{{$key}} :</label>
+					<label title="Input: {{$key}}">{{$item.Description}} :</label>
 					<input name="{{$key}}" value="{{$item.Default}}" {{if $item.Required}}required{{end}}>
-					<span class="help">{{$item.Description}}</span>
 				{{else}}
-					<label>{{$key}} :</label>
+					<label title="Input: {{$key}}">{{$item.Description}} :</label>
 					<input name="{{$key}}" value="{{$item.Default}}" {{if $item.Required}}required{{end}}>
-					<span class="help">{{$item.Description}}</span>
 				{{end}}
 			</div>
 			{{end}}


### PR DESCRIPTION
I have fixed the order of input items for `WorkflowDispatch` dialog
screenshots:
![screenshots1](https://github.com/pangliang/gitea/assets/22593101/cb3a8bef-45b6-4174-898f-7b757fb1c8bf)
![screenshots2](https://github.com/pangliang/gitea/assets/22593101/5a5d2a2b-36bc-4cb6-ac54-254c7611b697)
